### PR TITLE
Add unit tests for components and reducers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,19 @@
         "react-scripts": "5.0.1",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3725,6 +3737,107 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3733,6 +3846,14 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6459,6 +6580,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.11.2.tgz",
@@ -6821,6 +6949,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6934,6 +7073,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9498,6 +9645,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11481,6 +11638,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -11645,6 +11813,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -14307,6 +14485,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -15647,6 +15839,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,15 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js"
+    }
   }
 }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/test/LeaderBoardItem.test.js
+++ b/src/test/LeaderBoardItem.test.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import LeaderBoardItem from '../components/LeaderBoardItem'
+
+describe('LeaderBoardItem', () => {
+  const mockUser = {
+    id: 'sarahedo',
+    name: 'Sarah Edo',
+    answers: { q1: 'optionOne', q2: 'optionTwo' },
+    questions: ['q3', 'q4', 'q5'],
+  }
+
+  it('renders without crashing', () => {
+    const { container } = render(<LeaderBoardItem user={mockUser} />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the user name', () => {
+    const { getByText } = render(<LeaderBoardItem user={mockUser} />)
+    expect(getByText('Sarah Edo')).toBeTruthy()
+  })
+
+  it('displays the user id', () => {
+    const { getByText } = render(<LeaderBoardItem user={mockUser} />)
+    expect(getByText('sarahedo')).toBeTruthy()
+  })
+
+  it('displays the correct answered questions count', () => {
+    const { getByText } = render(<LeaderBoardItem user={mockUser} />)
+    expect(getByText('Answered Questions : 2')).toBeTruthy()
+  })
+
+  it('displays the correct created questions count', () => {
+    const { getByText } = render(<LeaderBoardItem user={mockUser} />)
+    expect(getByText('Created Questions : 3')).toBeTruthy()
+  })
+
+  it('displays the correct score', () => {
+    const { getByText } = render(<LeaderBoardItem user={mockUser} />)
+    expect(getByText('Score : 5')).toBeTruthy()
+  })
+})

--- a/src/test/Nav.test.js
+++ b/src/test/Nav.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import Nav from '../components/Nav'
+
+jest.mock('react-router-dom', () => ({
+  NavLink: ({ children, to, onClick, className }) => (
+    <a href={to} onClick={onClick}>{children}</a>
+  ),
+}))
+
+describe('Nav', () => {
+  const defaultProps = {
+    authedUserName: 'Sarah Edo',
+    updateShowLogin: jest.fn(),
+  }
+
+  it('renders without crashing', () => {
+    const { container } = render(<Nav {...defaultProps} />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays the authed user name', () => {
+    const { getByText } = render(<Nav {...defaultProps} />)
+    expect(getByText('Hello, Sarah Edo')).toBeTruthy()
+  })
+
+  it('renders navigation links', () => {
+    const { getByText } = render(<Nav {...defaultProps} />)
+    expect(getByText('Home')).toBeTruthy()
+    expect(getByText('New Question')).toBeTruthy()
+    expect(getByText('Leader Board')).toBeTruthy()
+    expect(getByText('Logout')).toBeTruthy()
+  })
+
+  it('calls updateShowLogin when Logout is clicked', () => {
+    const updateShowLogin = jest.fn()
+    const { getByText } = render(
+      <Nav authedUserName="Sarah Edo" updateShowLogin={updateShowLogin} />
+    )
+    fireEvent.click(getByText('Logout'))
+    expect(updateShowLogin).toHaveBeenCalledWith(true, '')
+  })
+})

--- a/src/test/Page404.test.js
+++ b/src/test/Page404.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Page404 from '../components/Page404'
+
+describe('Page404', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Page404 />)
+    expect(container).toBeTruthy()
+  })
+
+  it('displays "Page not found" text', () => {
+    const { getByText } = render(<Page404 />)
+    expect(getByText('Page not found')).toBeTruthy()
+  })
+})

--- a/src/test/RadioButtons.test.js
+++ b/src/test/RadioButtons.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import RadioButtons from '../components/RadioButtons'
+
+describe('RadioButtons', () => {
+  const mockQuestion = {
+    optionOne: { text: 'Learn React', votes: [] },
+    optionTwo: { text: 'Learn Angular', votes: [] },
+  }
+
+  it('renders without crashing', () => {
+    const selectOption = jest.fn()
+    const { container } = render(
+      <RadioButtons question={mockQuestion} selectOption={selectOption} />
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('displays both option texts', () => {
+    const selectOption = jest.fn()
+    const { getByText } = render(
+      <RadioButtons question={mockQuestion} selectOption={selectOption} />
+    )
+    expect(getByText('Learn React')).toBeTruthy()
+    expect(getByText('Learn Angular')).toBeTruthy()
+  })
+
+  it('calls selectOption when a radio button is clicked', () => {
+    const selectOption = jest.fn()
+    const { getByLabelText } = render(
+      <RadioButtons question={mockQuestion} selectOption={selectOption} />
+    )
+    fireEvent.click(getByLabelText('Learn Angular'))
+    expect(selectOption).toHaveBeenCalledWith('optionTwo')
+  })
+
+  it('defaults to optionOne when no savedOption is provided', () => {
+    const selectOption = jest.fn()
+    const { container } = render(
+      <RadioButtons question={mockQuestion} selectOption={selectOption} />
+    )
+    const checkedRadio = container.querySelector('input[value="optionOne"]')
+    expect(checkedRadio).toBeTruthy()
+  })
+})

--- a/src/test/SelectUser.test.js
+++ b/src/test/SelectUser.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import SelectUser from '../components/SelectUser'
+
+describe('SelectUser', () => {
+  it('renders without crashing', () => {
+    const selectUser = jest.fn()
+    const { container } = render(<SelectUser selectUser={selectUser} />)
+    expect(container).toBeTruthy()
+  })
+
+  it('renders the User label', () => {
+    const selectUser = jest.fn()
+    const { container } = render(<SelectUser selectUser={selectUser} />)
+    const label = container.querySelector('label')
+    expect(label.textContent).toBe('User')
+  })
+
+  it('renders the form element', () => {
+    const selectUser = jest.fn()
+    const { container } = render(<SelectUser selectUser={selectUser} />)
+    expect(container.querySelector('form')).toBeTruthy()
+  })
+
+  it('renders a select input', () => {
+    const selectUser = jest.fn()
+    const { container } = render(<SelectUser selectUser={selectUser} />)
+    const select = container.querySelector('[role="combobox"]')
+    expect(select).toBeTruthy()
+  })
+})

--- a/src/test/TabPanel.test.js
+++ b/src/test/TabPanel.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import TabPanel from '../components/TabPanel'
+
+describe('TabPanel', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <TabPanel value={0} index={0}>
+        <div>Content</div>
+      </TabPanel>
+    )
+    expect(container).toBeTruthy()
+  })
+
+  it('shows children when value matches index', () => {
+    const { getByText } = render(
+      <TabPanel value={0} index={0}>
+        <div>Visible Content</div>
+      </TabPanel>
+    )
+    expect(getByText('Visible Content')).toBeTruthy()
+  })
+
+  it('hides content when value does not match index', () => {
+    const { container } = render(
+      <TabPanel value={1} index={0}>
+        <div>Hidden Content</div>
+      </TabPanel>
+    )
+    const panel = container.querySelector('[role="tabpanel"]')
+    expect(panel).toHaveAttribute('hidden')
+  })
+
+  it('has correct aria attributes', () => {
+    const { container } = render(
+      <TabPanel value={0} index={0}>
+        <div>Content</div>
+      </TabPanel>
+    )
+    const panel = container.querySelector('[role="tabpanel"]')
+    expect(panel).toHaveAttribute('id', 'simple-tabpanel-0')
+    expect(panel).toHaveAttribute('aria-labelledby', 'simple-tab-0')
+  })
+})

--- a/src/test/reducers.test.js
+++ b/src/test/reducers.test.js
@@ -1,0 +1,114 @@
+import authedUserReducer from '../reducers/authedUser'
+import questionsReducer from '../reducers/questions'
+import usersReducer from '../reducers/users'
+import { SET_AUTHED_USER } from '../actions/authedUser'
+import { RECEIVE_QUESTIONS, SAVE_ANSWER, ADD_QUESTION } from '../actions/questions'
+import { RECEIVE_USERS, SAVE_USER_ANSWER } from '../actions/users'
+import { ADD_QUESTION_ID_TO_USER } from '../actions/questions'
+
+describe('authedUser reducer', () => {
+  it('returns the initial state', () => {
+    expect(authedUserReducer(undefined, {})).toBeNull()
+  })
+
+  it('handles SET_AUTHED_USER', () => {
+    const action = {
+      type: SET_AUTHED_USER,
+      authedUser: 'sarahedo',
+    }
+    expect(authedUserReducer(null, action)).toEqual({
+      authedUser: 'sarahedo',
+    })
+  })
+})
+
+describe('questions reducer', () => {
+  it('returns the initial state', () => {
+    expect(questionsReducer(undefined, {})).toEqual({})
+  })
+
+  it('handles RECEIVE_QUESTIONS', () => {
+    const questions = {
+      q1: { id: 'q1', author: 'sarahedo' },
+    }
+    const action = { type: RECEIVE_QUESTIONS, questions }
+    expect(questionsReducer({}, action)).toEqual(questions)
+  })
+
+  it('handles ADD_QUESTION', () => {
+    const question = { id: 'newQ', author: 'sarahedo', optionOne: { text: 'a', votes: [] }, optionTwo: { text: 'b', votes: [] } }
+    const action = { type: ADD_QUESTION, question }
+    const result = questionsReducer({}, action)
+    expect(result.newQ).toEqual(question)
+  })
+
+  it('handles SAVE_ANSWER by adding vote when not answered', () => {
+    const initialState = {
+      q1: {
+        id: 'q1',
+        optionOne: { text: 'a', votes: [] },
+        optionTwo: { text: 'b', votes: [] },
+      },
+    }
+    const action = {
+      type: SAVE_ANSWER,
+      id: 'q1',
+      authUser: 'sarahedo',
+      answer: 'optionOne',
+      hasAnswered: false,
+    }
+    const result = questionsReducer(initialState, action)
+    expect(result.q1.optionOne.votes).toContain('sarahedo')
+  })
+
+  it('handles SAVE_ANSWER by removing vote when already answered', () => {
+    const initialState = {
+      q1: {
+        id: 'q1',
+        optionOne: { text: 'a', votes: ['sarahedo'] },
+        optionTwo: { text: 'b', votes: [] },
+      },
+    }
+    const action = {
+      type: SAVE_ANSWER,
+      id: 'q1',
+      authUser: 'sarahedo',
+      answer: 'optionOne',
+      hasAnswered: true,
+    }
+    const result = questionsReducer(initialState, action)
+    expect(result.q1.optionOne.votes).not.toContain('sarahedo')
+  })
+})
+
+describe('users reducer', () => {
+  it('returns the initial state', () => {
+    expect(usersReducer(undefined, {})).toEqual({})
+  })
+
+  it('handles RECEIVE_USERS', () => {
+    const users = {
+      sarahedo: { id: 'sarahedo', name: 'Sarah Edo' },
+    }
+    const action = { type: RECEIVE_USERS, users }
+    expect(usersReducer({}, action)).toEqual(users)
+  })
+
+  it('handles ADD_QUESTION_ID_TO_USER', () => {
+    const initialState = {
+      sarahedo: { id: 'sarahedo', questions: ['q1'] },
+    }
+    const action = { type: ADD_QUESTION_ID_TO_USER, id: 'q2', author: 'sarahedo' }
+    const result = usersReducer(initialState, action)
+    expect(result.sarahedo.questions).toEqual(['q1', 'q2'])
+  })
+
+  it('handles SAVE_USER_ANSWER', () => {
+    const initialState = {
+      sarahedo: { id: 'sarahedo', answers: {} },
+    }
+    const action = { type: SAVE_USER_ANSWER, id: 'q1', authUser: 'sarahedo', answer: 'optionOne' }
+    const result = usersReducer(initialState, action)
+    expect(result.sarahedo.answers).toEqual({ q1: 'optionOne' })
+  })
+})


### PR DESCRIPTION
## Summary
Add unit tests using React Testing Library and Jest for the would-you-rather-app project:

**Component tests:** Page404, Nav, LeaderBoardItem, TabPanel, RadioButtons, SelectUser
**Reducer tests:** authedUser, questions, users reducers covering initial state, all action types, vote add/remove logic

Added `src/setupTests.js` with jest-dom, installed `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event`. Added jest moduleNameMapper to fix react-router-dom v7 resolution.

**All 37 tests pass** (including 2 pre-existing tests).

## Review & Testing Checklist
- [ ] Run `npm test` to verify all tests pass locally
- [ ] Verify no production code was modified
- [ ] Check that the jest moduleNameMapper does not conflict with existing config