### PR TITLE
Add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npx eslint src/ --ext .js,.jsx
+
+      - name: Test
+        run: npm test
+        env:
+          CI: true
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow that runs on every pull request:
- **Lint**: Runs ESLint on src/ directory
- **Test**: Runs the test suite with CI=true
- **Build**: Runs production build
- **Caching**: node_modules cached based on package-lock.json hash for faster runs

Workflow file: `.github/workflows/ci.yml`